### PR TITLE
Add vServer project management with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 dist/
 *.egg-info/
+__pycache__/
+*.db

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ netcup-cli stop --vserver_name YOUR_VSERVER_NAME
 netcup-cli poweroff --vserver_name YOUR_VSERVER_NAME
 ```
 
+**Project Commands**
+You can organize vServers into projects stored locally in a SQLite database.
+```bash
+# Create a project
+netcup-cli project create myproject
+
+# Add all servers with a nickname matching 'web-' to the project
+netcup-cli project add --project myproject --nickname '^web-'
+
+# List projects and assigned servers
+netcup-cli project list
+```
+
 ## Disclaimer
 This package is not affiliated with, endorsed, or sponsored by Netcup GmbH. It is an independent project and is maintained solely by its contributors.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can organize vServers into projects stored locally in a SQLite database.
 netcup-cli project create myproject
 
 # Add all servers with a nickname matching 'web-' to the project
-netcup-cli project add --project myproject --nickname '^web-'
+netcup-cli project add --project myproject --nick '^web-'
 
 # List projects and assigned servers
 netcup-cli project list

--- a/netcup_cli/main.py
+++ b/netcup_cli/main.py
@@ -72,7 +72,8 @@ class CLI:
         project_add.add_argument('--project', required=True, help="Project name")
         group = project_add.add_mutually_exclusive_group(required=True)
         group.add_argument('--vserver', help="Add vServer by name")
-        group.add_argument('--nickname', help="Regex to match nickname")
+        group.add_argument('--nick', '--nickname', dest='nickname',
+                           help="Regex to match nickname")
         group.add_argument('--ip', help="Match IP address")
 
         project_remove = project_sub.add_parser("remove", help="Remove a server from a project")

--- a/netcup_cli/main.py
+++ b/netcup_cli/main.py
@@ -3,12 +3,15 @@ import sys
 import os
 import json
 import base64
+import re
 from getpass import getpass
 from netcup_webservice import NetcupWebservice
+from netcup_cli.project_manager import ProjectManager
 
 # Get the directory where the current script is located
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 CREDENTIALS_FILE = os.path.join(SCRIPT_DIR, "netcup_credentials.json")
+PROJECT_DB = os.path.join(SCRIPT_DIR, "projects.db")
 
 class CLI:
     def __init__(self):
@@ -55,6 +58,26 @@ class CLI:
 
         poweroff_parser = subparsers.add_parser("poweroff", help="Power off a vServer")
         poweroff_parser.add_argument('--vserver_name', required=True, help="Name of the vServer to power off")
+
+        # Project management subcommands
+        project_parser = subparsers.add_parser("project", help="Manage projects")
+        project_sub = project_parser.add_subparsers(dest="project_command")
+
+        project_create = project_sub.add_parser("create", help="Create a project")
+        project_create.add_argument('name', help="Project name")
+
+        project_list = project_sub.add_parser("list", help="List projects")
+
+        project_add = project_sub.add_parser("add", help="Add servers to a project")
+        project_add.add_argument('--project', required=True, help="Project name")
+        group = project_add.add_mutually_exclusive_group(required=True)
+        group.add_argument('--vserver', help="Add vServer by name")
+        group.add_argument('--nickname', help="Regex to match nickname")
+        group.add_argument('--ip', help="Match IP address")
+
+        project_remove = project_sub.add_parser("remove", help="Remove a server from a project")
+        project_remove.add_argument('--project', required=True, help="Project name")
+        project_remove.add_argument('--vserver', required=True, help="vServer name")
 
     def save_credentials(self, loginname, password):
         encoded_loginname = base64.b64encode(loginname.encode()).decode()
@@ -171,6 +194,37 @@ class CLI:
             result = netcup_ws.poweroff_vserver(vserver_name=args.vserver_name)
             print(result)
 
+        elif args.command == "project":
+            pm = ProjectManager(PROJECT_DB)
+            if args.project_command == "create":
+                pm.create_project(args.name)
+                print(f"Project '{args.name}' created")
+            elif args.project_command == "list":
+                for project in pm.list_projects():
+                    servers = ", ".join(project["servers"]) if project["servers"] else ""
+                    print(f"{project['name']}: {servers}")
+            elif args.project_command == "add":
+                if args.vserver:
+                    pm.add_server(args.project, args.vserver)
+                    print(f"Added {args.vserver} to {args.project}")
+                else:
+                    servers = netcup_ws.get_vservers()
+                    matched = []
+                    for srv in servers:
+                        info = netcup_ws.get_vserver_information(str(srv))
+                        if args.nickname and re.search(args.nickname, info.get('vServerNickname', '')):
+                            matched.append(info['vServerName'])
+                        elif args.ip and args.ip in info.get('ips', []):
+                            matched.append(info['vServerName'])
+                    for srv in matched:
+                        pm.add_server(args.project, srv)
+                    print(f"Added {len(matched)} servers to {args.project}")
+            elif args.project_command == "remove":
+                pm.remove_server(args.project, args.vserver)
+                print(f"Removed {args.vserver} from {args.project}")
+            else:
+                print("Unknown project command")
+
         else:
             print(f"Unknown command: {args.command}")
             self.parser.print_help()
@@ -178,3 +232,7 @@ class CLI:
 def main():
     cli = CLI()
     cli.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/netcup_cli/main.py
+++ b/netcup_cli/main.py
@@ -13,6 +13,13 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 CREDENTIALS_FILE = os.path.join(SCRIPT_DIR, "netcup_credentials.json")
 PROJECT_DB = os.path.join(SCRIPT_DIR, "projects.db")
 
+def print_progress(current, total, bar_length=50):
+    percent = float(current) / total
+    arrow = '-' * int(round(percent * bar_length) - 1) + '>'
+    spaces = ' ' * (bar_length - len(arrow))
+    sys.stdout.write(f'\rProgress: [{arrow}{spaces}] {int(percent*100)}%')
+    sys.stdout.flush()
+
 class CLI:
     def __init__(self):
         self.parser = argparse.ArgumentParser(
@@ -211,12 +218,15 @@ class CLI:
                 else:
                     servers = netcup_ws.get_vservers()
                     matched = []
-                    for srv in servers:
+                    total_servers = len(servers)
+                    print(f"Found {total_servers} servers")
+                    for i, srv in enumerate(servers, 1):
                         info = netcup_ws.get_vserver_information(str(srv))
-                        if args.nickname and re.search(args.nickname, info.get('vServerNickname', '')):
+                        if args.nickname and re.search(args.nickname, info['vServerNickname']):
                             matched.append(info['vServerName'])
-                        elif args.ip and args.ip in info.get('ips', []):
+                        elif args.ip and args.ip in info['ips']:
                             matched.append(info['vServerName'])
+                        print_progress(i, total_servers)
                     for srv in matched:
                         pm.add_server(args.project, srv)
                     print(f"Added {len(matched)} servers to {args.project}")

--- a/netcup_cli/project_manager.py
+++ b/netcup_cli/project_manager.py
@@ -1,0 +1,62 @@
+import sqlite3
+import os
+
+class ProjectManager:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
+    def _init_db(self):
+        c = self.conn.cursor()
+        c.execute(
+            "CREATE TABLE IF NOT EXISTS projects (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)"
+        )
+        c.execute(
+            "CREATE TABLE IF NOT EXISTS project_servers (project_id INTEGER, vserver_name TEXT, UNIQUE(project_id, vserver_name))"
+        )
+        self.conn.commit()
+
+    def create_project(self, name):
+        with self.conn:
+            self.conn.execute("INSERT OR IGNORE INTO projects (name) VALUES (?)", (name,))
+
+    def list_projects(self):
+        c = self.conn.cursor()
+        projects = []
+        for pid, name in c.execute("SELECT id, name FROM projects ORDER BY name").fetchall():
+            servers = [row[0] for row in c.execute(
+                "SELECT vserver_name FROM project_servers WHERE project_id=? ORDER BY vserver_name",
+                (pid,),
+            ).fetchall()]
+            projects.append({"name": name, "servers": servers})
+        return projects
+
+    def add_server(self, project_name, vserver_name):
+        c = self.conn.cursor()
+        row = c.execute("SELECT id FROM projects WHERE name=?", (project_name,)).fetchone()
+        if not row:
+            raise ValueError(f"Project '{project_name}' does not exist")
+        pid = row[0]
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR IGNORE INTO project_servers (project_id, vserver_name) VALUES (?, ?)",
+                (pid, vserver_name),
+            )
+
+    def remove_server(self, project_name, vserver_name):
+        c = self.conn.cursor()
+        row = c.execute("SELECT id FROM projects WHERE name=?", (project_name,)).fetchone()
+        if not row:
+            raise ValueError(f"Project '{project_name}' does not exist")
+        pid = row[0]
+        with self.conn:
+            self.conn.execute(
+                "DELETE FROM project_servers WHERE project_id=? AND vserver_name=?",
+                (pid, vserver_name),
+            )
+
+    def __del__(self):
+        if hasattr(self, 'conn'):
+            self.conn.close()


### PR DESCRIPTION
## Summary
- create `ProjectManager` class using SQLite to store project-server mapping
- extend CLI with `project` command for creating/listing/managing projects
- document new project commands
- ignore cache and SQLite files

## Testing
- `pip install -e .`
- `python netcup_cli/main.py -h`
- `python -m netcup_cli.main login --user dummy --password dummy`
- `python -m netcup_cli.main project create testproj`
- `python -m netcup_cli.main project add --project testproj --vserver vs123`
- `python -m netcup_cli.main project list`


------
https://chatgpt.com/codex/tasks/task_e_6852943860f4832c9817140f80e468bf